### PR TITLE
Move pip deps to conda run dependencies (v0, meta.yaml)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -125,7 +125,7 @@ test:
     - python nrel5mw_driver.py
     - cd ..
     - cd ..
-    - pytest --unit
+    - pytest --unit wisdem/test/
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "4.1.0" %}
 {% set name = "wisdem" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # MPI now supported! https://conda-forge.org/docs/maintainer/knowledge_base.html#message-passing-interface-mpi
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
@@ -79,6 +79,7 @@ requirements:
     - {{ mpi }}      # [mpi != 'nompi' and not win]
   run:
         #    - cython
+    - jsonmerge
     - jsonschema
     - matplotlib-base
     - moorpy >=1.2
@@ -98,7 +99,10 @@ requirements:
     - simpy
     - sortedcontainers
     - statsmodels >=0.14.5
-    - {{ mpi }}      # [mpi != 'nompi' and not win]    
+    - windio
+    - wombat >=0.13.1
+    - orbit-nrel
+    - {{ mpi }}      # [mpi != 'nompi' and not win]
 
 # Putting numpy in 'host' section and pin_compatible in run per conda-forge guidance
 test:
@@ -113,11 +117,7 @@ test:
     - examples
     - examples/02_reference_turbines
   commands:
-    - pip install orbit-nrel
-    - pip install jsonmerge
-    - pip install windIO
     - pip install dearpygui   # [not aarch64]
-    - pip install wombat >=0.13.1
     - wisdem --help
     - compare_designs -h
     - cd examples
@@ -125,6 +125,7 @@ test:
     - python nrel5mw_driver.py
     - cd ..
     - cd ..
+    - pytest --unit
 
 
 about:


### PR DESCRIPTION
## Summary
- **orbit-nrel**, **jsonmerge**, **windio**, and **wombat** are now available on conda-forge and have been moved from `pip install` in the test phase to proper conda `run` dependencies.
- Removed the corresponding `pip install` commands from the test section since conda now handles these packages.
- Added `pytest --unit` to the test commands to run unit tests during packaging.
- Bumped the build number.

## Relationship to #96
This PR and #96 address the same core issue (pip-installed deps should be conda deps) but take different approaches. **Only one should be merged:**

| | **#97 (this PR, v0)** | **#96 (v1)** |
|---|---|---|
| **Scope** | Minimal — deps only | Full recipe modernization |
| **Recipe format** | Keeps legacy `meta.yaml` | Migrates to `recipe.yaml` (rattler-build) |
| **CI/build scripts** | Unchanged | Re-rendered with conda-smithy |
| **Risk** | Low — small, targeted diff | Higher — larger changeset |

If a conservative, minimal change is preferred, merge this PR. If the recipe should be modernized at the same time, merge #96 instead.

## Test plan
- [ ] CI builds and tests pass on all platforms
- [ ] All moved dependencies are resolved by the conda solver
- [ ] `pytest --unit` runs successfully during the test phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)